### PR TITLE
Added URLs generation

### DIFF
--- a/src/Tests/WaffleEngineTests.cs
+++ b/src/Tests/WaffleEngineTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using System.Linq;
 using VerifyXunit;
 using WaffleGenerator;
 using Xunit;
@@ -14,10 +15,10 @@ public class WaffleEngineTests :
     {
         #region textUsage
 
-        var text = WaffleEngine.Text(
+        var link = WaffleEngine.Text(
             paragraphs: 1,
             includeHeading: true);
-        Debug.WriteLine(text);
+        Debug.WriteLine(link);
 
         #endregion
     }
@@ -31,6 +32,19 @@ public class WaffleEngineTests :
             paragraphs: 2,
             includeHeading: true,
             includeHeadAndBody: true);
+        Debug.WriteLine(text);
+
+        #endregion
+    }
+
+    [Fact]
+    public void LinkWaffleSample()
+    {
+        #region linkUsage
+
+        var text = WaffleEngine.Link(
+            countryTopLevel: true,
+            pathLength: 2);
         Debug.WriteLine(text);
 
         #endregion
@@ -114,6 +128,59 @@ public class WaffleEngineTests :
         var random = new Random(0);
         var html = WaffleEngine.Html(random, 1, true, true);
         return Verify(html);
+    }
+
+    [Fact]
+    public void LinkNoCountry()
+    {
+        var link = WaffleEngine.Link(null);
+        var uri = new Uri(link);
+        var host = uri.Host.Split('.');
+
+        Assert.Equal(3, host.Length);
+        Assert.False(Constants.domainsCountry.Contains(host[0]));
+    }
+
+    [Fact]
+    public void LinkCountrySubDomain()
+    {
+        var link = WaffleEngine.Link(false);
+        var uri = new Uri(link);
+        var host = uri.Host.Split('.');
+
+        Assert.Equal(3, host.Length);
+        Assert.True(Constants.domainsCountry.Contains(host[0]));
+    }
+
+    [Fact]
+    public void LinkCountryTopLevelDomain()
+    {
+        var link = WaffleEngine.Link(true);
+        var uri = new Uri(link);
+        var host = uri.Host.Split('.');
+
+        Assert.Equal(4, host.Length);
+        Assert.False(Constants.domainsCountry.Contains(host[0]));
+        Assert.True(Constants.domainsCountry.Contains(host[3]));
+    }
+
+    [Fact]
+    public void LinkWellFormed()
+    {
+        var link = WaffleEngine.Link(null, 2);
+        var uri = new Uri(link);
+        var host = uri.Host.Split('.');
+        var path = uri.PathAndQuery.Split('/');
+
+        Assert.True(Constants.schemes.Contains(uri.Scheme));
+        Assert.Equal(3, host.Length);
+        Assert.True(Constants.domainsSub.Contains(host[0]));
+        Assert.True(Constants.domains.Contains(host[1]));
+        Assert.True(Constants.domainsTop.Contains(host[2]));
+        Assert.Equal(0, path[0].Length);
+        Assert.True(Constants.paths.Contains(path[1]));
+        Assert.True(Constants.paths.Contains(path[2].Split('.')[0]));
+        Assert.True(Constants.extensions.Contains(path[2].Split('.')[1]));
     }
 
     public WaffleEngineTests(ITestOutputHelper output) :

--- a/src/WaffleGenerator/Constants.cs
+++ b/src/WaffleGenerator/Constants.cs
@@ -1,4 +1,7 @@
 // ReSharper disable StringLiteralTypo
+#if DEBUG
+public
+#endif
 class Constants
 {
     public static string[] preamblePhrases =
@@ -619,5 +622,84 @@ class Constants
     public static bool[] maybeParagraph =
     {
         false, false,true, false
+    };
+
+    public static string[] schemes =
+    {
+        "http", "https", "ftp", "ssh", "git"
+    };
+
+    public static string[] domainsSub =
+    {
+        "www", "mail", "remote", "blog", "webmail", "server", "ns1", "ns2", "smtp", "secure", "vpn",
+        "m", "shop", "ftp", "mail2", "test", "portal", "ns", "ww1", "host", "support", "dev", "web",
+        "bbs"
+    };
+
+    public static string[] domains =
+    {
+        "2Dimensions", "500px", "7cups", "9gag", "about", "academia", "alik", "anobii", "archive",
+        "audiojungle", "avizo", "blip", "badoo", "bandcamp", "basecamp", "bazar", "behance", "bitbucket",
+        "bitcoinforum", "blogger", "bodybuilding", "bookcrossing", "brew", "buymeacoffee", "buzzfeed",
+        "cnet", "canva", "capfriendly", "carbonmade", "cash", "cent", "championat", "chatujme", "chessru",
+        "cloob", "codecademy", "codechef", "codementor", "coderwall", "codewars", "colourlovers", "contently",
+        "coroflot", "cracked", "creativemarket", "crevado", "crunchyroll", "dev", "dailymotion",
+        "designspiration", "deviantart", "discogs", "disqus", "dribbble", "ebay", "ello", "etsy", "eyeem",
+        "facebook", "facenama", "fandom", "filmo", "fiverr", "flickr", "flightradar24", "flipboard",
+        "fortnitetrackerchallenges", "gdprofiles", "gpsies", "gamespot", "giphy", "github", "gitlab",
+        "gitee", "goodreads", "gumroad", "gunsandammo", "gurushots", "hackerone", "hackerrank", "house-mixes",
+        "houzz", "hubpages", "hubski", "ifttt", "imageshack", "imgup", "insanejournal", "instagram",
+        "instructables", "investing", "issuu", "itch", "jimdosite", "kaggle", "keybase", "kik", "kiwifarms",
+        "kongregate", "linux", "launchpad", "leetcode", "letterboxd", "livejournal", "liveleak", "lobste",
+        "mstdn", "medium", "meetme", "mixcloud", "myanimelist", "myspace", "native-instrumentsforum",
+        "npmjs", "npmjs", "namemc", "nationstates", "nationstates", "newgrounds", "ok", "opencollective",
+        "openstreetmap", "otzovik", "ourdjtalk", "pcpartpicker", "psnprofiles", "packagist", "pastebin",
+        "patreon", "periscope", "pexels", "photobucket", "pinkbike", "pinterest", "pixabay", "googlestore",
+        "pling", "plug", "pokemonshowdown", "polygon", "producthunt", "promodj", "quora", "rateyourmusic",
+        "redbubble", "reddit", "redsun", "repl", "researchgate", "reverbnation", "roblox", "sbazar", "mit",
+        "scribd", "shitpostbot", "slack", "slideshare", "smashcast", "smule", "soundcloud", "sourceforge",
+        "speedrun", "splits", "sporcle", "sports", "sports-tracker", "spotify", "robertsspaceindustries",
+        "steamcommunity", "steamcommunity", "sublimetext", "t-mobile", "tamtamt", "taringa", "tellonym",
+        "tiktok", "tinder", "tm-ladderindex", "tradingview", "trakt", "trashbox", "trello", "skyscanner",
+        "tripadvisor", "twitch", "twitter", "ultimate-guitar", "unsplash", "vk", "vsco", "venmo", "viadeoen",
+        "vimeo", "virgool", "virustotal", "wattpad", "weheartit", "webnode", "wikidot", "wikipedia", "wix",
+        "wordpress", "wordpress", "yandex", "younow", "youpic", "youtube", "zhihu", "zomato", "akniga",
+        "authorstream", "baby", "babyblog", "boingboing", "couchsurfing", "d3", "dailykos", "dating",
+        "devrant", "drive2", "egpu", "easyen", "fanpop", "fixya", "fl", "geocaching", "gfycat", "habr",
+        "hackster", "imgsrc", "interpals", "irecommend", "kwork", "pentestit", "last", "leasehackr",
+        "livelib", "metacritic", "mixer", "moikrug", "opennet", "pedsovet", "pikabu", "echo", "segmentfault",
+        "sparkpeople", "spletnik", "toster", "travellerspoint", "warriorforum"
+    };
+
+    public static string[] domainsTop =
+    {
+        "com", "org", "net", "int", "edu", "gov", "mil", "arpa"
+    };
+
+    public static string[] domainsCountry =
+    {
+       "ac", "ad", "ae", "af", "ag", "ai", "al", "am", "ao", "aq", "ar", "as", "at", "au", "aw", "ax",
+       "az", "ba", "bb", "bd", "be", "bf", "bg", "bh", "bi", "bj", "bm", "bn", "bo", "br", "bt", "bw",
+       "by", "bz", "ca", "cc", "cd", "cf", "cg", "ch", "ci", "ck", "cl", "cm", "cn", "co", "cr", "cu",
+       "cv", "cw", "cx", "cy", "cz", "de", "dj", "dk", "dm", "do", "dz", "ec", "ee", "eg", "er", "es",
+       "et", "eu", "fi", "fj", "fk", "fm", "fo", "fr", "ga", "gd", "ge", "gf", "gg", "gh", "gi", "gl",
+       "gm", "gn", "gp", "gq", "gs", "gt", "gu", "gw", "gy", "hk", "hm", "hn", "hr", "ht", "hu", "id",
+       "ie", "il", "im", "in", "io", "iq", "ir", "it", "je", "jm", "jo", "jp", "ke", "kg", "kh", "ki",
+       "km", "kn", "kp", "kr", "kw", "ky", "kz", "la", "lb", "lc", "li", "lk", "lk", "lr", "ls", "lt",
+       "lu", "lv", "ly", "ma", "mc", "md", "me", "mg", "mk", "ml", "mm", "mn", "mo", "mp", "mq", "mr",
+       "ms", "mt", "mu", "mv", "mx", "my", "mz", "na", "nc", "ne", "nf", "ng", "ni", "nl", "no", "np",
+       "nr", "nu", "nz", "om", "pa", "pe", "pf", "pg", "ph", "pk", "pl", "pm", "pn", "pr", "ps", "pt",
+       "pw", "py", "qa", "re", "ro", "rs", "ru", "rw", "sa", "sb", "sc", "sd", "se", "sg", "sh", "si",
+       "sk", "sl", "sm", "so", "sr", "ss", "st", "su", "sv", "sx", "sy", "sz", "tc", "td", "tf", "tg",
+       "th", "tj", "tk", "tl", "tm", "tn", "to", "tr", "tt", "tv", "tw", "tz", "ua", "ug", "uk", "us",
+       "uy", "uz", "va", "vc", "ve", "vg", "vi", "vn", "vu", "wf", "ws", "ye", "yt", "za", "zm", "zw"
+    };
+
+    public static string[] paths = {
+        "index", "home", "search", "contacts", "about", "info", "credits"
+    };
+
+    public static string[] extensions = {
+        "htm", "html", "php", "cgi", "asp", "aspx"
     };
 }

--- a/src/WaffleGenerator/UrlEngine.cs
+++ b/src/WaffleGenerator/UrlEngine.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+
+class UrlEngine
+{
+    private Random _random = new Random();
+    private List<string> _chosen = new List<string>();
+
+    public string Build(bool? countryTopLevel, int pathLength)
+    {
+        var builder = new StringBuilder();
+        builder.AppendFormat("{0}://", Choice(Constants.schemes));
+        if (countryTopLevel != null && !countryTopLevel.Value) {
+            builder.AppendFormat("{0}.", Choice(Constants.domainsCountry));
+        }
+        else {
+            builder.AppendFormat("{0}.", Choice(Constants.domainsSub));
+        }
+        builder.AppendFormat("{0}.", Choice(Constants.domains));
+        builder.AppendFormat("{0}", Choice(Constants.domainsTop));
+        if (countryTopLevel != null && countryTopLevel.Value) {
+            builder.AppendFormat(".{0}", Choice(Constants.domainsCountry));
+        }
+        if (pathLength == 0) {
+            builder.Append("/");
+        }
+        else {
+            for (var i = 0; i < pathLength; i++) {
+                builder.AppendFormat("/{0}", Choice(Constants.paths, false));
+            }
+        }
+        if (pathLength > 0) {
+            builder.AppendFormat(".{0}", Choice(Constants.extensions));
+        }
+        return builder.ToString();
+    }
+
+    private string Choice(IEnumerable<string> source, bool unique = true)
+    {
+        var item = source.ElementAt(_random.Next(0, source.Count() - 1));
+        var exists = _chosen.Contains(item);
+        if (exists) {
+            if (unique) {
+                Choice(source);
+            }
+            return item;
+        }
+        _chosen.Add(item);
+        return item;
+    }
+}

--- a/src/WaffleGenerator/WaffleEngine.cs
+++ b/src/WaffleGenerator/WaffleEngine.cs
@@ -123,5 +123,15 @@ namespace WaffleGenerator
 
             return builder.ToString();
         }
+
+        public static string Link(bool? countryTopLevel, int? pathLength = null)
+        {
+            if (pathLength != null && pathLength.Value < 0) throw new ArgumentException(nameof(pathLength));
+
+            if (pathLength == null) {
+                return new UrlEngine().Build(countryTopLevel, new Random().Next(0, 3));
+            }
+            return new UrlEngine().Build(countryTopLevel, pathLength.Value);
+        }
     }
 }


### PR DESCRIPTION
I tried to be adhere to "spirit" of actual API design. But URLs are a different kind of text in respect to titles and paragraph.
For now is designed in this way:
```csharp
var link = WaffleEngine.Link(countryTopLevel: true, pathLength: 2);
```
`countryTopLevel`: **null** -> omits country
`countryTopLevel`: **true** -> uses country in top level domain: www.example.com.us
`countryTopLevel`: **false** -> uses country in subdomain: us.example.org
`pathLength`: **null** ->  generates a limited random number of path elements
`pathLength`: 0 -> www.example.com/
`pathLength`: 5 ->  www.example.com/one/two/three/four/five.php
All parts of URL are chosen randomly.

I'm available for questions, changes or move/PR code to another project you suggest.